### PR TITLE
Gateway should deny sql queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: 'check and test'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -47,7 +47,7 @@ jobs:
     name: 'check formatting'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Docker meta
         id: docker_meta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,11 +4320,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4338,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0a6b588ef4aec1b5ddbbfdacd9ef04e00b979617765b03174318ee1f3a"
+checksum = "50c715249705afa1e32be79dabfd35e2ef0f1cc02ad2cf48c9d1e20026ee637b"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452d929748ac948a10481fff4123affead32c553cf362841c5103dd508bdfc16"
+checksum = "bef9a94a27345fb31e3fcb5f5e9f592bb4847493b07fa1e47dd9fde2222f2e28"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df64e094f6d2099339f9e82b5b38440b159757b6920878f28316243f8166c8d1"
+checksum = "c31fe73cd259527e24dc2dbfe64bc95e5ddfcd2b2731f670a11ff72b2be2c25b"
 dependencies = [
  "const-hex",
  "dunce",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bc2d6dfc2a19fd56644494479510f98b1ee929e04cf0d4aa45e98baa3e545b"
+checksum = "afaffed78bfb17526375754931e045f96018aa810844b29c7aef823266dd4b4b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -4656,9 +4656,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4497156948bd342b52038035a6fa514a89626e37af9d2c52a5e8d8ebcc7ee479"
+checksum = "70aba06097b6eda3c15f6eebab8a6339e121475bcf08bbe6758807e716c372a1"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ debug = true
 
 [workspace.dependencies]
 anyhow = "1.0"
-alloy-primitives = { version = "0.7.0", features = ["serde"] }
-alloy-sol-types = "0.7.0"
+alloy-primitives = { version = "0.7.1", features = ["serde"] }
+alloy-sol-types = "0.7.1"
 axum = { version = "0.7.5", default-features = false, features = [
     "json",
     "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ secp256k1 = { version = "0.29", default-features = false }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.116", features = ["raw_value"] }
-serde_with = "3.7.0"
+serde_with = "3.8.1"
 siphasher = "1.0.1"
 thegraph-core = "0.3.1"
 thegraph-graphql-http = "0.2.1"

--- a/gateway-framework/src/http/middleware/request_tracing.rs
+++ b/gateway-framework/src/http/middleware/request_tracing.rs
@@ -56,7 +56,7 @@ where
             target: REQUEST_SPAN_TARGET,
             "client request",  // name
             graph_env = %self.env_id,
-            query_id = field::Empty,
+            request_id = field::Empty,
             selector = field::Empty,
         )
         .entered();

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -58,7 +58,7 @@ use crate::{
     block_constraints::{resolve_block_requirements, rewrite_query, BlockRequirements},
     indexer_client::{check_block_error, IndexerClient, ResponsePayload},
     reports::{self, serialize_attestation},
-    sql_constraints::validate_sql_query,
+    sql_constraints::invalidate_sql_query,
     unattestable_errors::{miscategorized_attestable, miscategorized_unattestable},
 };
 
@@ -285,7 +285,7 @@ async fn handle_client_query_inner(
     let mut context = AgoraContext::new(&payload.query, &variables)
         .map_err(|err| Error::BadQuery(anyhow!("{err}")))?;
 
-    validate_sql_query(&context)?;
+    invalidate_sql_query(&context)?;
 
     tracing::info!(
         target: CLIENT_REQUEST_TARGET,

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -54,23 +54,13 @@ use self::{
     attestation_header::GraphAttestation, context::Context, l2_forwarding::forward_request_to_l2,
     query_selector::QuerySelector, query_settings::QuerySettings,
 };
-
-use crate::block_constraints::{resolve_block_requirements, rewrite_query, BlockRequirements};
-use crate::chains::ChainReader;
-use crate::indexer_client::{check_block_error, IndexerClient, ResponsePayload};
-use crate::indexers::indexing;
-use crate::indexing_performance::{self, IndexingPerformance};
-use crate::reports::{self, serialize_attestation, KafkaClient};
-use crate::sql_constraints::validate_sql_query;
-use crate::topology::{Deployment, GraphNetwork, Subgraph};
-use crate::unattestable_errors::{miscategorized_attestable, miscategorized_unattestable};
-
-use self::attestation_header::GraphAttestation;
-use self::auth::AuthToken;
-use self::context::Context;
-use self::l2_forwarding::forward_request_to_l2;
-use self::query_selector::QuerySelector;
-use self::query_settings::QuerySettings;
+use crate::{
+    block_constraints::{resolve_block_requirements, rewrite_query, BlockRequirements},
+    indexer_client::{check_block_error, IndexerClient, ResponsePayload},
+    reports::{self, serialize_attestation},
+    sql_constraints::validate_sql_query,
+    unattestable_errors::{miscategorized_attestable, miscategorized_unattestable},
+};
 
 mod attestation_header;
 pub mod context;

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -32,7 +32,7 @@ use gateway_framework::{
         discovery::Status,
         indexing_performance::{IndexingPerformance, Snapshot},
     },
-    reporting::{with_metric, KafkaClient, METRICS},
+    reporting::{with_metric, KafkaClient, CLIENT_REQUEST_TARGET, INDEXER_REQUEST_TARGET, METRICS},
     scalar::{ReceiptStatus, ScalarReceipt},
     topology::network::{Deployment, GraphNetwork, Subgraph},
 };
@@ -170,7 +170,7 @@ pub async fn handle_query(
         };
         let (legacy_status_message, legacy_status_code) = reports::legacy_status(&result);
         tracing::info!(
-            target: reports::CLIENT_QUERY_TARGET,
+            target: CLIENT_REQUEST_TARGET,
             start_time_ms = timestamp,
             deployment,
             %status_message,
@@ -241,7 +241,7 @@ async fn handle_client_query_inner(
         .last()
         .map(|deployment| deployment.manifest.network.clone())
         .ok_or_else(|| Error::SubgraphNotFound(anyhow!("no matching deployments")))?;
-    tracing::info!(target: reports::CLIENT_QUERY_TARGET, subgraph_chain);
+    tracing::info!(target: CLIENT_REQUEST_TARGET, subgraph_chain);
 
     let manifest_min_block = deployments.last().unwrap().manifest.min_block;
     let chain = ctx.chains.chain(&subgraph_chain).await;
@@ -284,7 +284,7 @@ async fn handle_client_query_inner(
     let mut context = AgoraContext::new(&payload.query, &variables)
         .map_err(|err| Error::BadQuery(anyhow!("{err}")))?;
     tracing::info!(
-        target: reports::CLIENT_QUERY_TARGET,
+        target: CLIENT_REQUEST_TARGET,
         query = %payload.query,
         %variables,
     );
@@ -305,7 +305,7 @@ async fn handle_client_query_inner(
         budget = (*(user_budget_usd * grt_per_usd * one_grt) as u128).min(max_budget);
     }
     tracing::info!(
-        target: reports::CLIENT_QUERY_TARGET,
+        target: CLIENT_REQUEST_TARGET,
         query_count = 1,
         budget_grt = (budget as f64 * 1e-18) as f32,
     );
@@ -481,8 +481,8 @@ async fn handle_client_query_inner(
             // there's a race between creating this span and another indexer responding which will
             // close the outer client_query span.
             let span = tracing::info_span!(
-                target: reports::INDEXER_QUERY_TARGET,
-                "indexer_query",
+                target: INDEXER_REQUEST_TARGET,
+                "indexer_request",
                 indexer = ?selection.indexing.indexer,
             );
             let receipt_signer = ctx.receipt_signer;
@@ -511,7 +511,7 @@ async fn handle_client_query_inner(
         let total_indexer_fees_usd =
             USD(NotNan::new(total_indexer_fees_grt as f64 * 1e-18).unwrap() / grt_per_usd);
         tracing::info!(
-            target: reports::CLIENT_QUERY_TARGET,
+            target: CLIENT_REQUEST_TARGET,
             indexer_fees_grt = (total_indexer_fees_grt as f64 * 1e-18) as f32,
             indexer_fees_usd = *total_indexer_fees_usd.0 as f32,
         );
@@ -644,7 +644,7 @@ async fn handle_indexer_query(
 
     let latency_ms = ctx.response_time.as_millis() as u32;
     tracing::info!(
-        target: reports::INDEXER_QUERY_TARGET,
+        target: INDEXER_REQUEST_TARGET,
         %deployment,
         url = %selection.url,
         blocks_behind = selection.blocks_behind,
@@ -714,7 +714,7 @@ async fn handle_indexer_query_inner(
         .collect::<Vec<&str>>()
         .join("; ");
     tracing::info!(
-        target: reports::INDEXER_QUERY_TARGET,
+        target: INDEXER_REQUEST_TARGET,
         indexer_errors = errors_repr,
     );
 

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -5,5 +5,6 @@ pub mod indexer_client;
 pub mod indexers;
 pub mod indexings_blocklist;
 pub mod reports;
+pub mod sql_constraints;
 pub mod subgraph_studio;
 pub mod unattestable_errors;

--- a/graph-gateway/src/sql_constraints.rs
+++ b/graph-gateway/src/sql_constraints.rs
@@ -3,92 +3,28 @@ use cost_model::Context;
 use gateway_framework::errors::Error;
 use graphql::graphql_parser::query::OperationDefinition;
 
-pub fn validate_sql_query(ctx: &Context<String>) -> Result<(), Error> {
-    for operation in &ctx.operations {
-        match operation {
-            OperationDefinition::Query(query) => {
-                let items_not_sql = query
-                    .selection_set
-                    .items
-                    .iter()
-                    .filter_map(|selection| {
-                        if let graphql::graphql_parser::query::Selection::Field(field) = selection {
-                            if field.name != "sql" {
-                                return Some(field.name.as_str());
-                            }
-                        }
-                        None
-                    })
-                    .collect::<Vec<_>>();
-                if items_not_sql.len() > 0 {
-                    return Err(Error::BadQuery(anyhow!(
-                        "Fields [{}] are not SQL",
-                        items_not_sql.join(", ")
-                    )));
+pub fn invalidate_sql_query(ctx: &Context<String>) -> Result<(), Error> {
+    if ctx.operations.iter().any(|operation| {
+        if let OperationDefinition::Query(query) = operation {
+            query.selection_set.items.iter().any(|selection| {
+                if let graphql::graphql_parser::query::Selection::Field(field) = selection {
+                    return field.name == "sql";
                 }
-            }
-            _ => continue,
+                false
+            })
+        } else {
+            false
         }
+    }) {
+        return Err(Error::BadQuery(anyhow!("Query contains SQL")));
     }
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_single_selection_set() {
-        let query = r#"
-            query {
-                sql(input: { query: "SELECT * FROM users" }) {
-                    id
-                    name
-                }
-            }
-        "#;
-        let variables = r#"{}"#;
-        let ctx = Context::new(query, variables).unwrap();
-        assert!(validate_sql_query(&ctx).is_ok());
-    }
-
-    #[test]
-    fn test_multi_selection_set() {
-        let query = r#"
-            query {
-                sql(input: { query: "SELECT * FROM users" }) {
-                    rows
-                    columns
-                }
-                sql(input: { query: "SELECT * FROM tokens" }) {
-                    id
-                    name
-                }
-            }
-        "#;
-        let variables = r#"{}"#;
-        let ctx = Context::new(query, variables).unwrap();
-        assert!(validate_sql_query(&ctx).is_ok());
-    }
-
-    #[test]
-    fn test_multi_selection_set_not_sql() {
-        let query = r#"
-            query {
-                sql(input: { query: "SELECT * FROM users" }) {
-                    id
-                    name
-                }
-                users {
-                    id
-                    name
-                }
-            }
-        "#;
-        let variables = r#"{}"#;
-        let ctx = Context::new(query, variables).unwrap();
-        assert!(validate_sql_query(&ctx).is_err());
-    }
 
     #[test]
     fn test_no_sql() {
@@ -106,9 +42,59 @@ mod tests {
         "#;
         let variables = r#"{}"#;
         let ctx = Context::new(query, variables).unwrap();
-        assert_eq!(
-            validate_sql_query(&ctx).err().unwrap().to_string(),
-            Error::BadQuery(anyhow!("Fields [tokens, users] are not SQL")).to_string()
-        );
+        assert!(invalidate_sql_query(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_single_selection_set() {
+        let query = r#"
+            query {
+                sql(input: { query: "SELECT * FROM users" }) {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert!(invalidate_sql_query(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_multi_selection_set_with_sql() {
+        let query = r#"
+            query {
+                sql(input: { query: "SELECT * FROM users" }) {
+                    id
+                    name
+                }
+                users {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert!(invalidate_sql_query(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_multi_sql_fields() {
+        let query = r#"
+            query {
+                sql(input: { query: "SELECT * FROM tokens" }) {
+                    id
+                    name
+                }
+                sql(input: { query: "SELECT * FROM users" }) {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert!(invalidate_sql_query(&ctx).is_err());
     }
 }

--- a/graph-gateway/src/sql_constraints.rs
+++ b/graph-gateway/src/sql_constraints.rs
@@ -1,0 +1,114 @@
+use anyhow::anyhow;
+use cost_model::Context;
+use gateway_framework::errors::Error;
+use graphql::graphql_parser::query::OperationDefinition;
+
+pub fn validate_sql_query(ctx: &Context<String>) -> Result<(), Error> {
+    for operation in &ctx.operations {
+        match operation {
+            OperationDefinition::Query(query) => {
+                let items_not_sql = query
+                    .selection_set
+                    .items
+                    .iter()
+                    .filter_map(|selection| {
+                        if let graphql::graphql_parser::query::Selection::Field(field) = selection {
+                            if field.name != "sql" {
+                                return Some(field.name.as_str());
+                            }
+                        }
+                        None
+                    })
+                    .collect::<Vec<_>>();
+                if items_not_sql.len() > 0 {
+                    return Err(Error::BadQuery(anyhow!(
+                        "Fields [{}] are not SQL",
+                        items_not_sql.join(", ")
+                    )));
+                }
+            }
+            _ => continue,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_selection_set() {
+        let query = r#"
+            query {
+                sql(input: { query: "SELECT * FROM users" }) {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert!(validate_sql_query(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_multi_selection_set() {
+        let query = r#"
+            query {
+                sql(input: { query: "SELECT * FROM users" }) {
+                    rows
+                    columns
+                }
+                sql(input: { query: "SELECT * FROM tokens" }) {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert!(validate_sql_query(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_multi_selection_set_not_sql() {
+        let query = r#"
+            query {
+                sql(input: { query: "SELECT * FROM users" }) {
+                    id
+                    name
+                }
+                users {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert!(validate_sql_query(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_no_sql() {
+        let query = r#"
+            query {
+                tokens {
+                    id
+                    name
+                }
+                users {
+                    id
+                    name
+                }
+            }
+        "#;
+        let variables = r#"{}"#;
+        let ctx = Context::new(query, variables).unwrap();
+        assert_eq!(
+            validate_sql_query(&ctx).err().unwrap().to_string(),
+            Error::BadQuery(anyhow!("Fields [tokens, users] are not SQL")).to_string()
+        );
+    }
+}

--- a/graph-gateway/tests/it_indexers_status_indexing_statuses.rs
+++ b/graph-gateway/tests/it_indexers_status_indexing_statuses.rs
@@ -12,7 +12,7 @@ fn test_deployment_id(deployment: &str) -> DeploymentId {
 
 #[tokio::test]
 async fn query_indexer_indexing_statuses() {
-    //// Given
+    //* Given
     let client = reqwest::Client::new();
     let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
         .parse()
@@ -23,13 +23,13 @@ async fn query_indexer_indexing_statuses() {
         test_deployment_id("QmSqxfDGyGenGFPkqw9sqnYar4XgzaioVWNvhw5QQ3RB1U"),
     ];
 
-    //// When
+    //* When
     let request = indexing_statuses::query(&client, status_url, &test_deployments);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
-    //// Then
+    //* Then
     assert_matches!(response, Ok(indexing_statuses) => {
         assert!(indexing_statuses.len() == 2);
         assert!(test_deployments.iter().all(|deployment| indexing_statuses.iter().any(|status| &status.subgraph == deployment)));

--- a/graph-gateway/tests/it_indexers_status_public_pois.rs
+++ b/graph-gateway/tests/it_indexers_status_public_pois.rs
@@ -15,7 +15,7 @@ fn test_deployment_id(deployment: &str) -> DeploymentId {
 
 #[tokio::test]
 async fn query_indexer_public_pois() {
-    //// Given
+    //* Given
     let client = reqwest::Client::new();
     let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
         .parse()
@@ -36,13 +36,13 @@ async fn query_indexer_public_pois() {
         ],
     };
 
-    //// When
+    //* When
     let request = public_poi::query(client, status_url, query);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
-    //// Then
+    //* Then
     assert_matches!(response, Ok(resp) => {
         assert_eq!(resp.public_proofs_of_indexing.len(), 2);
 
@@ -58,7 +58,7 @@ async fn query_indexer_public_pois() {
 /// Error with the following message: "query is too expensive".
 #[tokio::test]
 async fn requests_over_max_requests_per_query_should_fail() {
-    //// Given
+    //* Given
 
     let client = reqwest::Client::new();
     let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
@@ -75,19 +75,19 @@ async fn requests_over_max_requests_per_query_should_fail() {
             .collect(),
     };
 
-    //// When
+    //* When
     let request = public_poi::query(client, status_url, query);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
-    //// Then
+    //* Then
     assert!(response.is_err());
 }
 
 #[tokio::test]
 async fn send_batched_queries_and_merge_results() {
-    //// Given
+    //* Given
     let client = reqwest::Client::new();
     let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
         .parse()
@@ -99,14 +99,14 @@ async fn send_batched_queries_and_merge_results() {
         .map(|i| (deployment, i as BlockNumber))
         .collect::<Vec<_>>();
 
-    //// When
+    //* When
     let request =
         public_poi::merge_queries(client, status_url, pois_to_query, MAX_REQUESTS_PER_QUERY);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
-    //// Then
+    //* Then
     assert_eq!(response.len(), MAX_REQUESTS_PER_QUERY + 2);
     assert!(response.contains_key(&(deployment, 1)));
     assert!(response.contains_key(&(deployment, 2)));

--- a/graph-gateway/tests/it_indexers_status_version.rs
+++ b/graph-gateway/tests/it_indexers_status_version.rs
@@ -6,19 +6,19 @@ use tokio::time::timeout;
 
 #[tokio::test]
 async fn query_indexer_service_version() {
-    //// Given
+    //* Given
     let client = reqwest::Client::new();
     let version_url = "https://testnet-indexer-03-europe-cent.thegraph.com/version"
         .parse()
         .expect("Invalid version url");
 
-    //// When
+    //* When
     let request = version::query_indexer_service_version(&client, version_url);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
-    //// Then
+    //* Then
     // Assert version is present and greater than 0.1.0
     assert_matches!(response, Ok(version) => {
         assert!(version > semver::Version::new(0, 1, 0));

--- a/graph-gateway/tests/it_indexings_blocklist.rs
+++ b/graph-gateway/tests/it_indexings_blocklist.rs
@@ -25,7 +25,7 @@ fn test_deployment_id(deployment: &str) -> DeploymentId {
 
 #[tokio::test]
 async fn check_indexer_pois_should_find_matches() {
-    //// Given
+    //* Given
     let client = reqwest::Client::new();
 
     let indexer_addr = Address::default();
@@ -67,13 +67,13 @@ async fn check_indexer_pois_should_find_matches() {
         },
     ];
 
-    //// When
+    //* When
     let request = check_indexer_pois(client, indexer_addr, status_url, pois_to_query, 1);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
-    //// Then
+    //* Then
     let (address, pois) = response;
     assert_eq!(address, indexer_addr);
     assert_eq!(pois.len(), 2);


### PR DESCRIPTION
## Issue ([semiotic-ai Linear](https://linear.app/semiotic/issue/SQL-238/create-a-pr-for-the-eandn-gateway-to-deny-sql-queries))

As work takes place to add support for SQL queries the Gateway should invalidate such queries in the meantime.

## Solution

The Gateway should reject queries containing SQL fields.
